### PR TITLE
Added visual validation / messaging when user saves an entry

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -11,6 +11,7 @@
             </ResourceDictionary.MergedDictionaries>
             
             <!-- Converters -->
+            <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
             <converters:ListToStringConverter x:Key="ListToStringConverter"/>
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
             <converters:BoolToRadioConverter x:Key="BoolToRadioConverter"/>

--- a/ViewModels/EveningCheckInViewModel.cs
+++ b/ViewModels/EveningCheckInViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DailyCheckInJournal.Models;
@@ -57,6 +58,20 @@ namespace DailyCheckInJournal.ViewModels
 
         public ObservableCollection<Habit> AvailableHabits { get; } = new();
         public ObservableCollection<string> MistakeCategories { get; } = new();
+
+        private string? _successMessage;
+        public string? SuccessMessage
+        {
+            get => _successMessage;
+            set => SetProperty(ref _successMessage, value);
+        }
+
+        private bool _showSuccessMessage;
+        public bool ShowSuccessMessage
+        {
+            get => _showSuccessMessage;
+            set => SetProperty(ref _showSuccessMessage, value);
+        }
 
         private string? _mustDoFromMorning;
         public string? MustDoFromMorning
@@ -176,6 +191,23 @@ namespace DailyCheckInJournal.ViewModels
             };
 
             await _dataService.SaveCheckInAsync(checkIn);
+            
+            // Show encouraging success message
+            SuccessMessage = "💙 Well done! Your evening check-in has been saved. Reflecting on your day is a powerful act of self-care. Keep going! 🌙";
+            ShowSuccessMessage = true;
+            
+            // Clear the message after 5 seconds
+            var timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(5)
+            };
+            timer.Tick += (s, e) =>
+            {
+                ShowSuccessMessage = false;
+                SuccessMessage = null;
+                timer.Stop();
+            };
+            timer.Start();
         }
     }
 }

--- a/ViewModels/MorningCheckInViewModel.cs
+++ b/ViewModels/MorningCheckInViewModel.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DailyCheckInJournal.Models;
@@ -70,6 +73,20 @@ namespace DailyCheckInJournal.ViewModels
         }
 
         public ObservableCollection<Habit> AvailableHabits { get; } = new();
+
+        private string? _successMessage;
+        public string? SuccessMessage
+        {
+            get => _successMessage;
+            set => SetProperty(ref _successMessage, value);
+        }
+
+        private bool _showSuccessMessage;
+        public bool ShowSuccessMessage
+        {
+            get => _showSuccessMessage;
+            set => SetProperty(ref _showSuccessMessage, value);
+        }
 
         public ICommand SaveCommand { get; }
         public ICommand AddMedicationCommand { get; }
@@ -173,6 +190,23 @@ namespace DailyCheckInJournal.ViewModels
             };
 
             await _dataService.SaveCheckInAsync(checkIn);
+            
+            // Show encouraging success message
+            SuccessMessage = "✨ Great job! Your morning check-in has been saved. You're taking care of yourself, and that matters! 🌟";
+            ShowSuccessMessage = true;
+            
+            // Clear the message after 5 seconds
+            var timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(5)
+            };
+            timer.Tick += (s, e) =>
+            {
+                ShowSuccessMessage = false;
+                SuccessMessage = null;
+                timer.Stop();
+            };
+            timer.Start();
         }
     }
 }

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DailyCheckInJournal.Models;
@@ -81,6 +82,20 @@ namespace DailyCheckInJournal.ViewModels
         {
             get => _newHabitName;
             set => SetProperty(ref _newHabitName, value);
+        }
+
+        private string? _successMessage;
+        public string? SuccessMessage
+        {
+            get => _successMessage;
+            set => SetProperty(ref _successMessage, value);
+        }
+
+        private bool _showSuccessMessage;
+        public bool ShowSuccessMessage
+        {
+            get => _showSuccessMessage;
+            set => SetProperty(ref _showSuccessMessage, value);
         }
 
         public ICommand SaveSettingsCommand { get; }
@@ -171,6 +186,23 @@ namespace DailyCheckInJournal.ViewModels
                 _notificationService.CancelReminder(true);
                 _notificationService.CancelReminder(false);
             }
+            
+            // Show encouraging success message
+            SuccessMessage = "✅ Settings saved successfully! Your preferences have been updated. Thank you for customizing your wellness journey! 💚";
+            ShowSuccessMessage = true;
+            
+            // Clear the message after 5 seconds
+            var timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(5)
+            };
+            timer.Tick += (s, e) =>
+            {
+                ShowSuccessMessage = false;
+                SuccessMessage = null;
+                timer.Stop();
+            };
+            timer.Start();
         }
 
         private async void AddHabit()

--- a/Views/EveningCheckInView.xaml
+++ b/Views/EveningCheckInView.xaml
@@ -154,9 +154,23 @@
                 <TextBox Text="{Binding Notes}" MinHeight="100" TextWrapping="Wrap" AcceptsReturn="True" Margin="10"/>
             </GroupBox>
 
+            <!-- Success Message -->
+            <Border Background="#E8F5E9" BorderBrush="#4CAF50" BorderThickness="2" 
+                    CornerRadius="5" Padding="15,10" Margin="0,20,0,15"
+                    Visibility="{Binding ShowSuccessMessage, Converter={StaticResource BoolToVisibilityConverter}}"
+                    HorizontalAlignment="Center"
+                    MaxWidth="600">
+                <TextBlock Text="{Binding SuccessMessage}" 
+                           FontSize="14" 
+                           Foreground="#2E7D32"
+                           TextWrapping="Wrap"
+                           FontWeight="SemiBold"
+                           TextAlignment="Center"/>
+            </Border>
+            
             <!-- Save Button -->
             <Button Content="Save Evening Check-In" Command="{Binding SaveCommand}" 
-                    HorizontalAlignment="Center" Padding="20,10" FontSize="16" Margin="0,20,0,0"/>
+                    HorizontalAlignment="Center" Padding="20,10" FontSize="16" Margin="0,0,0,0"/>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/Views/MorningCheckInView.xaml
+++ b/Views/MorningCheckInView.xaml
@@ -194,9 +194,23 @@
                 </StackPanel>
             </GroupBox>
 
+            <!-- Success Message -->
+            <Border Background="#E8F5E9" BorderBrush="#4CAF50" BorderThickness="2" 
+                    CornerRadius="5" Padding="15,10" Margin="0,20,0,15"
+                    Visibility="{Binding ShowSuccessMessage, Converter={StaticResource BoolToVisibilityConverter}}"
+                    HorizontalAlignment="Center"
+                    MaxWidth="600">
+                <TextBlock Text="{Binding SuccessMessage}" 
+                           FontSize="14" 
+                           Foreground="#2E7D32"
+                           TextWrapping="Wrap"
+                           FontWeight="SemiBold"
+                           TextAlignment="Center"/>
+            </Border>
+            
             <!-- Save Button -->
             <Button Content="Save Morning Check-In" Command="{Binding SaveCommand}" 
-                    HorizontalAlignment="Center" Padding="20,10" FontSize="16" Margin="0,20,0,0"/>
+                    HorizontalAlignment="Center" Padding="20,10" FontSize="16" Margin="0,0,0,0"/>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -91,9 +91,23 @@
                 </StackPanel>
             </GroupBox>
 
+            <!-- Success Message -->
+            <Border Background="#E8F5E9" BorderBrush="#4CAF50" BorderThickness="2" 
+                    CornerRadius="5" Padding="15,10" Margin="0,20,0,15"
+                    Visibility="{Binding ShowSuccessMessage, Converter={StaticResource BoolToVisibilityConverter}}"
+                    HorizontalAlignment="Center"
+                    MaxWidth="600">
+                <TextBlock Text="{Binding SuccessMessage}" 
+                           FontSize="14" 
+                           Foreground="#2E7D32"
+                           TextWrapping="Wrap"
+                           FontWeight="SemiBold"
+                           TextAlignment="Center"/>
+            </Border>
+            
             <!-- Save Button -->
             <Button Content="Save Settings" Command="{Binding SaveSettingsCommand}" 
-                    HorizontalAlignment="Center" Padding="20,10" FontSize="16" Margin="0,20,0,0"/>
+                    HorizontalAlignment="Center" Padding="20,10" FontSize="16" Margin="0,0,0,0"/>
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Description
The issue was that after a user clicks the save button there's no way for them to (visually) see that the information was saved. Added messaging so they know their entry was saved


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add transient in-app success notifications after saving in Morning, Evening, and Settings views, auto-hiding after 5 seconds.
> 
> - **UI/Views**:
>   - Add success message banner in `Views/MorningCheckInView.xaml`, `Views/EveningCheckInView.xaml`, and `Views/SettingsView.xaml` using a styled `Border` bound to `ShowSuccessMessage`/`SuccessMessage`.
>   - Register `BooleanToVisibilityConverter` in `App.xaml` for visibility binding.
>   - Minor layout tweak: remove extra top margin from save buttons in affected views.
> - **ViewModels**:
>   - `MorningCheckInViewModel`, `EveningCheckInViewModel`, `SettingsViewModel`:
>     - Add `SuccessMessage` and `ShowSuccessMessage` properties.
>     - After successful save, set an encouraging message and show banner; auto-clear via `DispatcherTimer` after 5 seconds.
>     - Add `using System.Windows.Threading` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02f3806c4637c25d66cf1c74593dd9db86a3b4b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->