### PR TITLE
OptionToViewPreviousDays

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,6 +115,20 @@ ViewModels coordinate between the views and services. I used the MVVM pattern be
 - Integrates with Google Drive service for authentication
 - Saves settings and immediately applies changes (like theme switching)
 
+**CalendarViewModel.cs**:
+- Manages calendar display and date selection
+- Loads all check-in dates to highlight days with entries
+- Provides date selection functionality with automatic check-in loading
+- Emits events when users request to view full day details
+- Integrates with MainViewModel for navigation to DayView
+
+**DayViewViewModel.cs**:
+- Displays a selected day's check-in in read-only mode
+- Separates morning and evening check-in data for clear presentation
+- Loads all check-in details including medications, habits, triggers, coping strategies, etc.
+- Uses ObservableCollections for dynamic UI updates
+- Designed for viewing historical data without editing capabilities
+
 **Design Decision**: I used CommunityToolkit.Mvvm for the ViewModels. This library provides:
 - `ObservableObject` base class with automatic property change notifications
 - `RelayCommand` and `AsyncRelayCommand` for command implementation
@@ -135,6 +149,20 @@ Views are pure XAML with minimal code-behind. I kept code-behind to just `Initia
 - ScrollViewers wrap all views to handle content overflow gracefully
 - Consistent spacing using Margin properties (I considered using a Spacing property but stuck with Margin for broader compatibility)
 
+**CalendarView.xaml**:
+- Uses WPF's built-in Calendar control for date selection
+- Displays a preview of selected day's check-in summary
+- Shows morning and evening check-in highlights
+- Provides "View Full Details" button to navigate to complete day view
+- Refresh button to reload check-in dates
+
+**DayView.xaml**:
+- Read-only view for displaying complete check-in details
+- Separates morning and evening sections for clarity
+- Uses TextBlocks instead of TextBoxes to prevent editing
+- Displays all check-in data including medications, habits, triggers, coping strategies, etc.
+- Uses CollectionToVisibilityConverter to show/hide sections based on data availability
+
 **Design Decision**: I removed the `PlaceholderText` attributes from TextBoxes because WPF doesn't natively support placeholders. While I could have created a custom control, I prioritized getting the core functionality working first. This is a good candidate for future enhancement.
 
 ### Converters
@@ -146,6 +174,8 @@ I created several value converters to handle data transformation between ViewMod
 - **BoolToRadioConverter**: Handles three-state radio buttons (Yes/No/N/A) for nullable booleans
 - **NullToRadioConverter**: Specifically for the N/A option in radio button groups
 - **DateTimeToDateConverter**: Converts DateTime to Date for DatePicker controls
+- **NullToBoolConverter**: Converts null values to boolean for enabling/disabling UI elements
+- **CollectionToVisibilityConverter**: Shows/hides UI elements based on whether collections have items
 
 **Design Decision**: Converters are registered in App.xaml as resources, making them available application-wide. This follows the DRY principle.
 

--- a/App.xaml
+++ b/App.xaml
@@ -16,6 +16,8 @@
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
             <converters:BoolToRadioConverter x:Key="BoolToRadioConverter"/>
             <converters:NullToRadioConverter x:Key="NullToRadioConverter"/>
+            <converters:NullToBoolConverter x:Key="NullToBoolConverter"/>
+            <converters:CollectionToVisibilityConverter x:Key="CollectionToVisibilityConverter"/>
             <converters:DateTimeToDateConverter x:Key="DateTimeToDateConverter"/>
             
             <!-- ViewModel to View DataTemplates -->
@@ -33,6 +35,12 @@
             </DataTemplate>
             <DataTemplate DataType="{x:Type viewModels:SettingsViewModel}">
                 <views:SettingsView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type viewModels:CalendarViewModel}">
+                <views:CalendarView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type viewModels:DayViewViewModel}">
+                <views:DayView/>
             </DataTemplate>
         </ResourceDictionary>
     </Application.Resources>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -88,6 +88,8 @@ namespace DailyCheckInJournal
                         sp.GetRequiredService<WeeklyReviewViewModel>(),
                         sp.GetRequiredService<VisualizationViewModel>(),
                         sp.GetRequiredService<SettingsViewModel>(),
+                        sp.GetRequiredService<CalendarViewModel>(),
+                        sp.GetRequiredService<DayViewViewModel>(),
                         logger);
                 });
                 services.AddTransient<MorningCheckInViewModel>();
@@ -95,6 +97,8 @@ namespace DailyCheckInJournal
                 services.AddTransient<WeeklyReviewViewModel>();
                 services.AddTransient<VisualizationViewModel>();
                 services.AddTransient<SettingsViewModel>();
+                services.AddTransient<DayViewViewModel>();
+                services.AddTransient<CalendarViewModel>();
 
                 // Views
                 _logger?.LogDebug("Registering Views...");

--- a/Converters/ValueConverters.cs
+++ b/Converters/ValueConverters.cs
@@ -82,5 +82,35 @@ namespace DailyCheckInJournal.Converters
             return Binding.DoNothing;
         }
     }
+
+    public class NullToBoolConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return value != null;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class CollectionToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is System.Collections.ICollection collection)
+            {
+                return collection.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }
 

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -23,6 +23,8 @@
                         Style="{StaticResource NavButtonStyle}" Margin="5"/>
                 <Button Content="Visualizations" Command="{Binding NavigateToVisualizationCommand}" 
                         Style="{StaticResource NavButtonStyle}" Margin="5"/>
+                <Button Content="View Days" Command="{Binding NavigateToCalendarCommand}" 
+                        Style="{StaticResource NavButtonStyle}" Margin="5"/>
                 <Button Content="Settings" Command="{Binding NavigateToSettingsCommand}" 
                         Style="{StaticResource NavButtonStyle}" Margin="5"/>
             </StackPanel>

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -55,6 +55,13 @@ This approach ensures each layer is solid before building on top of it, resultin
 - Mistake frequency analysis
 - Active pattern displays
 
+### Calendar & Day View
+- Calendar interface to browse previous days
+- Visual indication of dates with check-ins
+- Quick preview of selected day's check-in summary
+- Full day view showing complete morning and evening check-in details
+- Read-only view for reviewing historical entries
+
 ### Additional Features
 - **Pattern Detection**: Automatically identifies patterns in energy, mood, sleep, mistakes, and overcommitment
 - **Notifications**: System notifications and in-app reminders for morning and evening check-ins

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive daily check-in and journaling system designed to help individual
 - **Morning & Evening Check-Ins**: Track energy levels, mood, sleep, habits, and more
 - **Weekly Reviews**: Comprehensive statistics and pattern analysis
 - **Data Visualizations**: Charts and graphs to visualize trends over time
+- **Calendar & Day View**: Browse previous days and view complete check-in history
 - **Pattern Detection**: Automatically identifies patterns in your data
 - **Notifications**: Reminders for morning and evening check-ins
 - **Customizable Themes**: Six themes including accessibility options

--- a/ViewModels/CalendarViewModel.cs
+++ b/ViewModels/CalendarViewModel.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DailyCheckInJournal.Models;
+using DailyCheckInJournal.Services;
+
+namespace DailyCheckInJournal.ViewModels
+{
+    public class CalendarViewModel : ObservableObject
+    {
+        private readonly IDataService _dataService;
+        private readonly ILoggerService? _logger;
+        private DateTime? _selectedDate;
+        private CheckIn? _selectedCheckIn;
+
+        public DateTime? SelectedDate
+        {
+            get => _selectedDate;
+            set
+            {
+                if (SetProperty(ref _selectedDate, value) && value.HasValue)
+                {
+                    _logger?.LogDebug($"Date selected: {value.Value:yyyy-MM-dd}");
+                    LoadCheckInForDate(value.Value);
+                }
+            }
+        }
+
+        public CheckIn? SelectedCheckIn
+        {
+            get => _selectedCheckIn;
+            set => SetProperty(ref _selectedCheckIn, value);
+        }
+
+        public ObservableCollection<DateTime> DatesWithCheckIns { get; } = new();
+
+        public ICommand ViewDayCommand { get; }
+        public ICommand LoadCheckInsCommand { get; }
+
+        public event Action<CheckIn>? ViewDayRequested;
+
+        public CalendarViewModel(IDataService dataService, ILoggerService? logger = null)
+        {
+            _dataService = dataService;
+            _logger = logger;
+            
+            ViewDayCommand = new RelayCommand(() =>
+            {
+                if (SelectedDate.HasValue && SelectedCheckIn != null)
+                {
+                    _logger?.LogDebug($"Requesting full day view for {SelectedDate.Value:yyyy-MM-dd}");
+                    ViewDayRequested?.Invoke(SelectedCheckIn);
+                }
+            }, () => SelectedDate.HasValue && SelectedCheckIn != null);
+
+            LoadCheckInsCommand = new RelayCommand(async () => await LoadCheckInsAsync());
+
+            // Load check-ins on initialization
+            _ = LoadCheckInsAsync();
+        }
+
+        private async Task LoadCheckInsAsync()
+        {
+            try
+            {
+                _logger?.LogDebug("Loading check-ins for calendar...");
+                var checkIns = await _dataService.GetAllCheckInsAsync();
+                
+                DatesWithCheckIns.Clear();
+                foreach (var checkIn in checkIns)
+                {
+                    DatesWithCheckIns.Add(checkIn.Date.Date);
+                }
+
+                _logger?.LogInformation($"Loaded {DatesWithCheckIns.Count} dates with check-ins");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error loading check-ins for calendar");
+            }
+        }
+
+        private async void LoadCheckInForDate(DateTime date)
+        {
+            try
+            {
+                _logger?.LogDebug($"Loading check-in for date: {date:yyyy-MM-dd}");
+                var checkIn = await _dataService.GetCheckInAsync(date);
+                SelectedCheckIn = checkIn;
+                
+                if (checkIn == null)
+                {
+                    _logger?.LogDebug($"No check-in found for {date:yyyy-MM-dd}");
+                }
+                else
+                {
+                    _logger?.LogDebug($"Check-in loaded for {date:yyyy-MM-dd}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, $"Error loading check-in for date {date:yyyy-MM-dd}");
+            }
+        }
+
+        public bool HasCheckIn(DateTime date)
+        {
+            return DatesWithCheckIns.Contains(date.Date);
+        }
+    }
+}
+

--- a/ViewModels/DayViewViewModel.cs
+++ b/ViewModels/DayViewViewModel.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DailyCheckInJournal.Models;
+using DailyCheckInJournal.Services;
+
+namespace DailyCheckInJournal.ViewModels
+{
+    public class DayViewViewModel : ObservableObject
+    {
+        private readonly ILoggerService? _logger;
+        private CheckIn? _checkIn;
+        private DateTime _viewDate;
+
+        public DateTime ViewDate
+        {
+            get => _viewDate;
+            set => SetProperty(ref _viewDate, value);
+        }
+
+        public CheckIn? CheckIn
+        {
+            get => _checkIn;
+            set
+            {
+                if (SetProperty(ref _checkIn, value))
+                {
+                    LoadCheckInData();
+                }
+            }
+        }
+
+        // Morning Check-In Properties
+        public bool HasMorningCheckIn => CheckIn?.Morning != null;
+        public int MorningEnergyLevel => CheckIn?.Morning?.EnergyLevel ?? 0;
+        public string? MorningMustDoToday => CheckIn?.Morning?.MustDoToday;
+        public int MorningCapacityFeeling => CheckIn?.Morning?.CapacityFeeling ?? 0;
+        public SleepQuality? MorningSleepQuality => CheckIn?.Morning?.SleepQuality;
+        public ObservableCollection<MedicationEntry> MorningMedications { get; } = new();
+        public ObservableCollection<HabitEntry> MorningHabitEntries { get; } = new();
+        public ObservableCollection<string> MorningGratitudeItems { get; } = new();
+        public ObservableCollection<TriggerEntry> MorningTriggers { get; } = new();
+        public ObservableCollection<CopingStrategy> MorningCopingStrategies { get; } = new();
+        public SensoryState? MorningSensoryState => CheckIn?.Morning?.SensoryState;
+        public ExecutiveFunctionState? MorningExecutiveFunction => CheckIn?.Morning?.ExecutiveFunction;
+        public EmotionalState? MorningEmotionalState => CheckIn?.Morning?.EmotionalState;
+        public DateTime? MorningCheckInTime => CheckIn?.Morning?.CheckInTime;
+
+        // Evening Check-In Properties
+        public bool HasEveningCheckIn => CheckIn?.Evening != null;
+        public bool? EveningMustDoCompleted => CheckIn?.Evening?.MustDoCompleted;
+        public int EveningEnergyLevel => CheckIn?.Evening?.EnergyLevel ?? 0;
+        public bool? EveningOvercommitted => CheckIn?.Evening?.Overcommitted;
+        public ObservableCollection<MistakeEntry> EveningCommonMistakes { get; } = new();
+        public EmotionalState? EveningEmotionalState => CheckIn?.Evening?.EmotionalState;
+        public ObservableCollection<string> EveningGratitudeItems { get; } = new();
+        public ObservableCollection<TriggerEntry> EveningTriggers { get; } = new();
+        public ObservableCollection<CopingStrategy> EveningCopingStrategies { get; } = new();
+        public ObservableCollection<HabitEntry> EveningHabitEntries { get; } = new();
+        public string? EveningNotes => CheckIn?.Evening?.Notes;
+        public DateTime? EveningCheckInTime => CheckIn?.Evening?.CheckInTime;
+
+        public DayViewViewModel(ILoggerService? logger = null)
+        {
+            _logger = logger;
+            ViewDate = DateTime.Today;
+        }
+
+        private void LoadCheckInData()
+        {
+            try
+            {
+                _logger?.LogDebug("Loading check-in data into DayViewViewModel...");
+
+                // Clear existing data
+                MorningMedications.Clear();
+                MorningHabitEntries.Clear();
+                MorningGratitudeItems.Clear();
+                MorningTriggers.Clear();
+                MorningCopingStrategies.Clear();
+                EveningCommonMistakes.Clear();
+                EveningGratitudeItems.Clear();
+                EveningTriggers.Clear();
+                EveningCopingStrategies.Clear();
+                EveningHabitEntries.Clear();
+
+                if (CheckIn == null)
+                {
+                    _logger?.LogDebug("No check-in data to load");
+                    OnPropertyChanged(nameof(HasMorningCheckIn));
+                    OnPropertyChanged(nameof(HasEveningCheckIn));
+                    return;
+                }
+
+                ViewDate = CheckIn.Date;
+
+                // Load morning data
+                if (CheckIn.Morning != null)
+                {
+                    foreach (var med in CheckIn.Morning.Medications)
+                        MorningMedications.Add(med);
+                    foreach (var habit in CheckIn.Morning.HabitEntries)
+                        MorningHabitEntries.Add(habit);
+                    foreach (var gratitude in CheckIn.Morning.GratitudeItems)
+                        MorningGratitudeItems.Add(gratitude);
+                    foreach (var trigger in CheckIn.Morning.Triggers)
+                        MorningTriggers.Add(trigger);
+                    foreach (var strategy in CheckIn.Morning.CopingStrategies)
+                        MorningCopingStrategies.Add(strategy);
+                }
+
+                // Load evening data
+                if (CheckIn.Evening != null)
+                {
+                    foreach (var mistake in CheckIn.Evening.CommonMistakes)
+                        EveningCommonMistakes.Add(mistake);
+                    foreach (var gratitude in CheckIn.Evening.GratitudeItems)
+                        EveningGratitudeItems.Add(gratitude);
+                    foreach (var trigger in CheckIn.Evening.Triggers)
+                        EveningTriggers.Add(trigger);
+                    foreach (var strategy in CheckIn.Evening.CopingStrategies)
+                        EveningCopingStrategies.Add(strategy);
+                    foreach (var habit in CheckIn.Evening.HabitEntries)
+                        EveningHabitEntries.Add(habit);
+                }
+
+                // Notify all properties changed
+                OnPropertyChanged(nameof(HasMorningCheckIn));
+                OnPropertyChanged(nameof(MorningEnergyLevel));
+                OnPropertyChanged(nameof(MorningMustDoToday));
+                OnPropertyChanged(nameof(MorningCapacityFeeling));
+                OnPropertyChanged(nameof(MorningSleepQuality));
+                OnPropertyChanged(nameof(MorningSensoryState));
+                OnPropertyChanged(nameof(MorningExecutiveFunction));
+                OnPropertyChanged(nameof(MorningEmotionalState));
+                OnPropertyChanged(nameof(MorningCheckInTime));
+
+                OnPropertyChanged(nameof(HasEveningCheckIn));
+                OnPropertyChanged(nameof(EveningMustDoCompleted));
+                OnPropertyChanged(nameof(EveningEnergyLevel));
+                OnPropertyChanged(nameof(EveningOvercommitted));
+                OnPropertyChanged(nameof(EveningEmotionalState));
+                OnPropertyChanged(nameof(EveningNotes));
+                OnPropertyChanged(nameof(EveningCheckInTime));
+
+                _logger?.LogInformation("Check-in data loaded successfully");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error loading check-in data");
+            }
+        }
+    }
+}
+

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -25,12 +25,15 @@ namespace DailyCheckInJournal.ViewModels
         public ICommand NavigateToWeeklyReviewCommand { get; }
         public ICommand NavigateToVisualizationCommand { get; }
         public ICommand NavigateToSettingsCommand { get; }
+        public ICommand NavigateToCalendarCommand { get; }
 
         private readonly MorningCheckInViewModel _morningCheckInViewModel;
         private readonly EveningCheckInViewModel _eveningCheckInViewModel;
         private readonly WeeklyReviewViewModel _weeklyReviewViewModel;
         private readonly VisualizationViewModel _visualizationViewModel;
         private readonly SettingsViewModel _settingsViewModel;
+        private readonly CalendarViewModel _calendarViewModel;
+        private readonly DayViewViewModel _dayViewViewModel;
 
         public MainViewModel(
             IDataService dataService,
@@ -41,6 +44,8 @@ namespace DailyCheckInJournal.ViewModels
             WeeklyReviewViewModel weeklyReviewViewModel,
             VisualizationViewModel visualizationViewModel,
             SettingsViewModel settingsViewModel,
+            CalendarViewModel calendarViewModel,
+            DayViewViewModel dayViewViewModel,
             ILoggerService? logger = null)
         {
             try
@@ -56,6 +61,8 @@ namespace DailyCheckInJournal.ViewModels
                 _weeklyReviewViewModel = weeklyReviewViewModel;
                 _visualizationViewModel = visualizationViewModel;
                 _settingsViewModel = settingsViewModel;
+                _calendarViewModel = calendarViewModel;
+                _dayViewViewModel = dayViewViewModel;
 
                 _logger?.LogDebug("Creating navigation commands...");
                 NavigateToMorningCheckInCommand = new RelayCommand(() => 
@@ -83,6 +90,19 @@ namespace DailyCheckInJournal.ViewModels
                     _logger?.LogDebug("Navigating to Settings");
                     CurrentView = _settingsViewModel;
                 });
+                NavigateToCalendarCommand = new RelayCommand(() => 
+                {
+                    _logger?.LogDebug("Navigating to Calendar");
+                    CurrentView = _calendarViewModel;
+                });
+
+                // Subscribe to calendar's view day request
+                _calendarViewModel.ViewDayRequested += (checkIn) =>
+                {
+                    _logger?.LogDebug($"Navigating to day view for {checkIn.Date:yyyy-MM-dd}");
+                    _dayViewViewModel.CheckIn = checkIn;
+                    CurrentView = _dayViewViewModel;
+                };
 
                 // Default to morning check-in
                 _logger?.LogDebug("Setting default view to Morning Check-In");

--- a/Views/CalendarView.xaml
+++ b/Views/CalendarView.xaml
@@ -1,0 +1,116 @@
+<UserControl x:Class="DailyCheckInJournal.Views.CalendarView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:mc="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="700" d:DesignWidth="1000">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Text="View Previous Days" FontSize="24" FontWeight="Bold" Margin="0,0,0,20" Grid.Row="0"/>
+
+        <!-- Calendar and Selected Day View -->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="400"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Calendar -->
+            <Border Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Padding="10" Margin="0,0,20,0">
+                <StackPanel>
+                    <TextBlock Text="Select a date to view check-in details" 
+                               FontSize="14" 
+                               Margin="0,0,0,10"
+                               TextWrapping="Wrap"/>
+                    
+                    <Calendar SelectedDate="{Binding SelectedDate}" 
+                              DisplayDate="{Binding SelectedDate, TargetNullValue={x:Static sys:DateTime.Today}}"
+                              Margin="0,0,0,10"/>
+
+                    <Button Content="Refresh Calendar" 
+                            Command="{Binding LoadCheckInsCommand}" 
+                            HorizontalAlignment="Stretch"
+                            Margin="0,10,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Selected Day Details -->
+            <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Padding="15">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock FontSize="18" FontWeight="Bold" Margin="0,0,0,15">
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="Check-In Details - {0:MMMM dd, yyyy}">
+                                    <Binding Path="SelectedDate"/>
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+
+                        <!-- No Check-In Message -->
+                        <TextBlock Text="No check-in found for this date." 
+                                   FontSize="14" 
+                                   Foreground="Gray"
+                                   Visibility="{Binding SelectedCheckIn, Converter={StaticResource NullToVisibilityConverter}}"
+                                   Margin="0,20,0,0"/>
+
+                        <!-- Check-In Details -->
+                        <StackPanel Visibility="{Binding SelectedCheckIn, Converter={StaticResource NullToVisibilityConverter}}">
+                            <!-- Morning Check-In Section -->
+                            <GroupBox Header="Morning Check-In" Margin="0,0,0,15" 
+                                      Visibility="{Binding SelectedCheckIn.Morning, Converter={StaticResource NullToVisibilityConverter}}">
+                                <StackPanel Margin="10">
+                                    <TextBlock Text="{Binding SelectedCheckIn.Morning.EnergyLevel, StringFormat='Energy Level: {0}/10'}" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding SelectedCheckIn.Morning.MustDoToday, StringFormat='Must Do: {0}'}" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding SelectedCheckIn.Morning.CapacityFeeling, StringFormat='Capacity Feeling: {0}/10'}" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding SelectedCheckIn.Morning.CheckInTime, StringFormat='Checked in at: {0:g}'}" 
+                                               FontStyle="Italic" 
+                                               Foreground="Gray" 
+                                               Margin="0,10,0,0"/>
+                                </StackPanel>
+                            </GroupBox>
+
+                            <!-- Evening Check-In Section -->
+                            <GroupBox Header="Evening Check-In" Margin="0,0,0,15"
+                                      Visibility="{Binding SelectedCheckIn.Evening, Converter={StaticResource NullToVisibilityConverter}}">
+                                <StackPanel Margin="10">
+                                    <TextBlock Text="{Binding SelectedCheckIn.Evening.EnergyLevel, StringFormat='Energy Level: {0}/10'}" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding SelectedCheckIn.Evening.MustDoCompleted, StringFormat='Must Do Completed: {0}'}" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding SelectedCheckIn.Evening.Overcommitted, StringFormat='Overcommitted: {0}'}" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding SelectedCheckIn.Evening.CheckInTime, StringFormat='Checked in at: {0:g}'}" 
+                                               FontStyle="Italic" 
+                                               Foreground="Gray" 
+                                               Margin="0,10,0,0"/>
+                                </StackPanel>
+                            </GroupBox>
+
+                            <TextBlock Text="Click 'View Full Details' to see all information for this day." 
+                                       FontSize="12" 
+                                       Foreground="Gray" 
+                                       Margin="0,10,0,0"
+                                       TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+        <!-- View Full Details Button -->
+        <Button Content="View Full Details" 
+                Command="{Binding ViewDayCommand}" 
+                HorizontalAlignment="Center" 
+                Padding="20,10" 
+                FontSize="16" 
+                Margin="0,20,0,0"
+                Grid.Row="2"
+                IsEnabled="{Binding SelectedDate, Converter={StaticResource NullToBoolConverter}}"/>
+    </Grid>
+</UserControl>
+

--- a/Views/CalendarView.xaml.cs
+++ b/Views/CalendarView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace DailyCheckInJournal.Views
+{
+    public partial class CalendarView : UserControl
+    {
+        public CalendarView()
+        {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/Views/DayView.xaml
+++ b/Views/DayView.xaml
@@ -1,0 +1,288 @@
+<UserControl x:Class="DailyCheckInJournal.Views.DayView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="700" d:DesignWidth="1000">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="20">
+            <TextBlock FontSize="24" FontWeight="Bold" Margin="0,0,0,10">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="Check-In Details - {0:MMMM dd, yyyy}">
+                        <Binding Path="ViewDate"/>
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+
+            <!-- No Check-In Message -->
+            <TextBlock Text="No check-in found for this date." 
+                       FontSize="16" 
+                       Foreground="Gray"
+                       Margin="0,20,0,0"
+                       Visibility="{Binding CheckIn, Converter={StaticResource NullToVisibilityConverter}}"/>
+
+            <!-- Morning Check-In Section -->
+            <GroupBox Header="Morning Check-In" Margin="0,0,0,15" 
+                      Visibility="{Binding HasMorningCheckIn, Converter={StaticResource BoolToVisibilityConverter}}">
+                <StackPanel Margin="10">
+                    <TextBlock Text="{Binding MorningEnergyLevel, StringFormat='Energy Level: {0}/10'}" Margin="0,0,0,5"/>
+                    <TextBlock Text="{Binding MorningMustDoToday, StringFormat='Must Do: {0}'}" Margin="0,0,0,5" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding MorningCapacityFeeling, StringFormat='Capacity Feeling: {0}/10'}" Margin="0,0,0,5"/>
+                    
+                    <!-- Sleep Quality -->
+                    <GroupBox Header="Sleep Quality" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningSleepQuality, Converter={StaticResource NullToVisibilityConverter}}">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding MorningSleepQuality.Quality, StringFormat='Quality: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="{Binding MorningSleepQuality.HoursSlept, StringFormat='Hours Slept: {0}'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="Restless Sleep" Margin="0,0,0,5" 
+                                       Visibility="{Binding MorningSleepQuality.Restless, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding MorningSleepQuality.Notes}" TextWrapping="Wrap" Margin="0,5,0,0"/>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- Medications -->
+                    <GroupBox Header="Medications" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningMedications, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding MorningMedications}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,5" Padding="10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Name, StringFormat='Name: {0}'}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding TimeTaken, StringFormat='Time Taken: {0:g}'}" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Dosage, StringFormat='Dosage: {0}'}" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Notes}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Sensory State -->
+                    <GroupBox Header="Sensory State" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningSensoryState, Converter={StaticResource NullToVisibilityConverter}}">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding MorningSensoryState.OverloadLevel, StringFormat='Overload Level: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="{Binding MorningSensoryState.Triggers, Converter={StaticResource ListToStringConverter}, StringFormat='Triggers: {0}'}" 
+                                       TextWrapping="Wrap" Margin="0,0,0,5"/>
+                            <TextBlock Text="{Binding MorningSensoryState.Notes}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- Executive Function -->
+                    <GroupBox Header="Executive Function" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningExecutiveFunction, Converter={StaticResource NullToVisibilityConverter}}">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding MorningExecutiveFunction.TaskInitiationDifficulty, StringFormat='Task Initiation Difficulty: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="{Binding MorningExecutiveFunction.TransitionDifficulty, StringFormat='Transition Difficulty: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="Time Blindness" Margin="0,0,0,5" 
+                                       Visibility="{Binding MorningExecutiveFunction.TimeBlindness, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="Hyperfocus Period" Margin="0,0,0,5" 
+                                       Visibility="{Binding MorningExecutiveFunction.HyperfocusPeriod, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding MorningExecutiveFunction.Notes}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- Emotional State -->
+                    <GroupBox Header="Emotional State" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningEmotionalState, Converter={StaticResource NullToVisibilityConverter}}">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding MorningEmotionalState.OverallMood, StringFormat='Overall Mood: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="{Binding MorningEmotionalState.OverwhelmLevel, StringFormat='Overwhelm Level: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="Meltdown" Margin="0,0,0,5" 
+                                       Visibility="{Binding MorningEmotionalState.Meltdown, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="Shutdown" Margin="0,0,0,5" 
+                                       Visibility="{Binding MorningEmotionalState.Shutdown, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding MorningEmotionalState.Notes}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- Habits -->
+                    <GroupBox Header="Habits" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningHabitEntries, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding MorningHabitEntries}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <CheckBox Content="{Binding HabitName}" IsChecked="{Binding Completed}" IsEnabled="False" Margin="0,2"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Gratitude -->
+                    <GroupBox Header="Gratitude / Positives" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningGratitudeItems, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding MorningGratitudeItems}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding .}" Margin="0,2" TextWrapping="Wrap"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Triggers -->
+                    <GroupBox Header="Triggers" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningTriggers, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding MorningTriggers}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,5" Padding="10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Description, StringFormat='Description: {0}'}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Category, StringFormat='Category: {0}'}" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Notes}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Coping Strategies -->
+                    <GroupBox Header="Coping Strategies" Margin="0,10,0,5" 
+                              Visibility="{Binding MorningCopingStrategies, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding MorningCopingStrategies}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,5" Padding="10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Strategy, StringFormat='Strategy: {0}'}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                            <TextBlock Text="Effective" Margin="0,0,0,5" 
+                                                       Visibility="{Binding Effective, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                            <TextBlock Text="{Binding Notes}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <TextBlock Text="{Binding MorningCheckInTime, StringFormat='Checked in at: {0:g}'}" 
+                               FontStyle="Italic" 
+                               Foreground="Gray" 
+                               Margin="0,10,0,0"/>
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Evening Check-In Section -->
+            <GroupBox Header="Evening Check-In" Margin="0,0,0,15" 
+                      Visibility="{Binding HasEveningCheckIn, Converter={StaticResource BoolToVisibilityConverter}}">
+                <StackPanel Margin="10">
+                    <TextBlock Text="{Binding EveningEnergyLevel, StringFormat='Energy Level: {0}/10'}" Margin="0,0,0,5"/>
+                    <TextBlock Text="{Binding EveningMustDoCompleted, StringFormat='Must Do Completed: {0}'}" Margin="0,0,0,5"/>
+                    <TextBlock Text="{Binding EveningOvercommitted, StringFormat='Overcommitted: {0}'}" Margin="0,0,0,5"/>
+
+                    <!-- Common Mistakes -->
+                    <GroupBox Header="Common Mistakes" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningCommonMistakes, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding EveningCommonMistakes}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,5" Padding="10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Category, StringFormat='Category: {0}'}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Tags, Converter={StaticResource ListToStringConverter}, StringFormat='Tags: {0}'}" 
+                                                       TextWrapping="Wrap" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding FreeTextNotes}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Emotional State -->
+                    <GroupBox Header="Emotional State" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningEmotionalState, Converter={StaticResource NullToVisibilityConverter}}">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding EveningEmotionalState.OverallMood, StringFormat='Overall Mood: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="{Binding EveningEmotionalState.OverwhelmLevel, StringFormat='Overwhelm Level: {0}/10'}" Margin="0,0,0,5"/>
+                            <TextBlock Text="Meltdown" Margin="0,0,0,5" 
+                                       Visibility="{Binding EveningEmotionalState.Meltdown, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="Shutdown" Margin="0,0,0,5" 
+                                       Visibility="{Binding EveningEmotionalState.Shutdown, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding EveningEmotionalState.Notes}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- Habits -->
+                    <GroupBox Header="Habits" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningHabitEntries, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding EveningHabitEntries}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <CheckBox Content="{Binding HabitName}" IsChecked="{Binding Completed}" IsEnabled="False" Margin="0,2"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Gratitude -->
+                    <GroupBox Header="Gratitude / Positives" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningGratitudeItems, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding EveningGratitudeItems}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding .}" Margin="0,2" TextWrapping="Wrap"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Triggers -->
+                    <GroupBox Header="Triggers" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningTriggers, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding EveningTriggers}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,5" Padding="10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Description, StringFormat='Description: {0}'}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Category, StringFormat='Category: {0}'}" Margin="0,0,0,5"/>
+                                            <TextBlock Text="{Binding Notes}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Coping Strategies -->
+                    <GroupBox Header="Coping Strategies" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningCopingStrategies, Converter={StaticResource CollectionToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding EveningCopingStrategies}" Margin="10">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,5" Padding="10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Strategy, StringFormat='Strategy: {0}'}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                            <TextBlock Text="Effective" Margin="0,0,0,5" 
+                                                       Visibility="{Binding Effective, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                            <TextBlock Text="{Binding Notes}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </GroupBox>
+
+                    <!-- Notes -->
+                    <GroupBox Header="Notes" Margin="0,10,0,5" 
+                              Visibility="{Binding EveningNotes, Converter={StaticResource NullToVisibilityConverter}}">
+                        <TextBlock Text="{Binding EveningNotes}" TextWrapping="Wrap" Margin="10"/>
+                    </GroupBox>
+
+                    <TextBlock Text="{Binding EveningCheckInTime, StringFormat='Checked in at: {0:g}'}" 
+                               FontStyle="Italic" 
+                               Foreground="Gray" 
+                               Margin="0,10,0,0"/>
+                </StackPanel>
+            </GroupBox>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>
+

--- a/Views/DayView.xaml.cs
+++ b/Views/DayView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace DailyCheckInJournal.Views
+{
+    public partial class DayView : UserControl
+    {
+        public DayView()
+        {
+            InitializeComponent();
+        }
+    }
+}
+


### PR DESCRIPTION
Feature: Add calendar feature to view previous days

- Implement CalendarViewModel and CalendarView for date browsing
- Add DayViewViewModel and DayView for read-only check-in display
- Integrate calendar navigation into MainViewModel
- Add CollectionToVisibilityConverter and NullToBoolConverter
- Update PROJECT_OVERVIEW, README, and ARCHITECTURE documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Calendar and Day read-only views with navigation and DI wiring to browse and view historical check-ins, plus supporting converters and docs updates.
> 
> - **UI/Views**
>   - Add `Views/CalendarView.xaml(.cs)` and `Views/DayView.xaml(.cs)` for browsing and read-only day details.
>   - Add "View Days" nav button in `MainWindow.xaml`.
>   - Register DataTemplates for `CalendarViewModel` and `DayViewViewModel` in `App.xaml`.
> - **ViewModels & Navigation**
>   - Add `CalendarViewModel` (loads dates, selects date, `ViewDayRequested` event, refresh command).
>   - Add `DayViewViewModel` (read-only presentation of morning/evening data with observable collections).
>   - Integrate into `MainViewModel`: new `NavigateToCalendarCommand` and event-based navigation to Day view.
> - **DI/Startup**
>   - Register `CalendarViewModel` and `DayViewViewModel`; inject into `MainViewModel` in `App.xaml.cs`.
> - **Converters**
>   - Add `NullToBoolConverter` and `CollectionToVisibilityConverter`; register in `App.xaml`.
> - **Docs**
>   - Update `ARCHITECTURE.md`, `PROJECT_OVERVIEW.md`, and `README.md` to document Calendar/Day views and converters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c0353f36f060174b0975c0fa08f6e9a796a55a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->